### PR TITLE
Bump `System.Drawing.Common` to `7.0.0`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -73,5 +73,8 @@
     <PackageVersion Include="System.Text.Encodings.Web" Version="7.0.0" />
     <PackageVersion Include="WindowsAzure.Storage" Version="9.3.3" />
     <PackageVersion Include="JetBrains.Annotations" Version="11.1.0" PrivateAssets="All" />
+
+    <!-- Pinning versions because of CG -->
+    <PackageVersion Include="System.Drawing.Common" Version="7.0.0" />
   </ItemGroup>
 </Project>

--- a/src/MIcrosoft.DotNet.Internal.Logging/Microsoft.DotNet.Internal.Logging.csproj
+++ b/src/MIcrosoft.DotNet.Internal.Logging/Microsoft.DotNet.Internal.Logging.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
     <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" />
     <PackageReference Include="Newtonsoft.Json" />
+    <PackageReference Include="System.Drawing.Common" />
     <PackageReference Include="System.Text.Encodings.Web" />
   </ItemGroup>
 


### PR DESCRIPTION
Resolves a CG alert: https://dev.azure.com/dnceng/internal/_workitems/edit/5369