### PR TITLE
Make service host inheritable

### DIFF
--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/ServiceHost.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/ServiceHost.cs
@@ -64,7 +64,7 @@ public partial class ServiceHost
 
     private readonly List<Func<Task>> _serviceCallbacks = new List<Func<Task>>();
 
-    private ServiceHost()
+    protected ServiceHost()
     {
     }
 

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/ServiceHost.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/ServiceHost.cs
@@ -59,10 +59,10 @@ public class HostEnvironment : IWebHostEnvironment,
 /// </summary>
 public partial class ServiceHost
 {
-    private readonly List<Action<IServiceCollection>> _configureServicesActions =
+    protected readonly List<Action<IServiceCollection>> _configureServicesActions =
         new List<Action<IServiceCollection>> {ConfigureDefaultServices};
 
-    private readonly List<Func<Task>> _serviceCallbacks = new List<Func<Task>>();
+    protected readonly List<Func<Task>> _serviceCallbacks = new List<Func<Task>>();
 
     protected ServiceHost()
     {
@@ -140,7 +140,7 @@ public partial class ServiceHost
         return this;
     }
 
-    private void ApplyConfigurationToServices(IServiceCollection services)
+    protected void ApplyConfigurationToServices(IServiceCollection services)
     {
         foreach (Action<IServiceCollection> act in _configureServicesActions)
         {
@@ -148,7 +148,7 @@ public partial class ServiceHost
         }
     }
 
-    private void RegisterStatelessService<TService>(
+    protected void RegisterStatelessService<TService>(
         string serviceTypeName,
         Func<StatelessServiceContext, TService> ctor) where TService : StatelessService
     {
@@ -250,7 +250,7 @@ public partial class ServiceHost
         return ConfigureServices(builder => builder.AddScoped<TStartup>());
     }
 
-    private void Start()
+    protected void Start()
     {
         foreach (Func<Task> svc in _serviceCallbacks)
         {


### PR DESCRIPTION
For https://github.com/dotnet/arcade-services/issues/2783, we will need to override https://github.com/dotnet/dnceng-shared/blob/0ab687d7e3c7cadd094faa6a66c82e8cc2f4a930/src/Microsoft.DotNet.ServiceFabric.ServiceHost/ServiceHost.cs#L242 as it's registering a WebService with hardcoded endpoints https://github.com/dotnet/dnceng-shared/blob/main/src/Microsoft.DotNet.ServiceFabric.ServiceHost/DelegatedStatelessWebService.cs.
This PR makes it so we can inherit ServiceHost to do that