### PR TITLE
Enable ServiceHost overrides

### DIFF
--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/DelegatedStatelessWebService.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/DelegatedStatelessWebService.cs
@@ -71,7 +71,7 @@ public class DelegatedStatelessWebService<TStartup> : StatelessService where TSt
     {
         return new[]
         {
-            CreateServiceInstanceListener("ServiceEndpoint");
+            CreateServiceInstanceListener("ServiceEndpoint")
         };
     }
 }

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/DelegatedStatelessWebService.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/DelegatedStatelessWebService.cs
@@ -67,13 +67,10 @@ public class DelegatedStatelessWebService<TStartup> : StatelessService where TSt
                         });
                 });
 
-    protected override IEnumerable<ServiceInstanceListener> CreateServiceInstanceListeners()
+    protected override IEnumerable<ServiceInstanceListener> CreateServiceInstanceListeners() => new[]
     {
-        return new[]
-        {
-            CreateServiceInstanceListener("ServiceEndpoint")
-        };
-    }
+        CreateServiceInstanceListener("ServiceEndpoint")
+    };
 }
 
 public class DelegatedStatelessWebServiceStartup<TStartup> : IStartup

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/DelegatedStatelessWebService.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/DelegatedStatelessWebService.cs
@@ -29,16 +29,13 @@ public class DelegatedStatelessWebService<TStartup> : StatelessService where TSt
         _configureServices = configureServices;
     }
 
-    protected override IEnumerable<ServiceInstanceListener> CreateServiceInstanceListeners()
-    {
-        return new[]
-        {
-            new ServiceInstanceListener(
+    protected ServiceInstanceListener CreateServiceInstanceListener(string endpointName) =>
+        new ServiceInstanceListener(
                 context =>
                 {
                     return new HttpSysCommunicationListener(
                         context,
-                        "ServiceEndpoint",
+                        endpointName,
                         (url, listener) =>
                         {
                             var builder = new WebHostBuilder()
@@ -68,7 +65,13 @@ public class DelegatedStatelessWebService<TStartup> : StatelessService where TSt
                                 .UseUrls(url)
                                 .Build();
                         });
-                })
+                });
+
+    protected override IEnumerable<ServiceInstanceListener> CreateServiceInstanceListeners()
+    {
+        return new[]
+        {
+            CreateServiceInstanceListener("ServiceEndpoint");
         };
     }
 }

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/ServiceHost.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/ServiceHost.cs
@@ -59,12 +59,12 @@ public class HostEnvironment : IWebHostEnvironment,
 /// </summary>
 public partial class ServiceHost
 {
-    protected readonly List<Action<IServiceCollection>> _configureServicesActions =
+    private readonly List<Action<IServiceCollection>> _configureServicesActions =
         new List<Action<IServiceCollection>> {ConfigureDefaultServices};
 
-    protected readonly List<Func<Task>> _serviceCallbacks = new List<Func<Task>>();
+    private readonly List<Func<Task>> _serviceCallbacks = new List<Func<Task>>();
 
-    protected ServiceHost()
+    private ServiceHost()
     {
     }
 
@@ -140,7 +140,7 @@ public partial class ServiceHost
         return this;
     }
 
-    protected void ApplyConfigurationToServices(IServiceCollection services)
+    private void ApplyConfigurationToServices(IServiceCollection services)
     {
         foreach (Action<IServiceCollection> act in _configureServicesActions)
         {
@@ -148,7 +148,7 @@ public partial class ServiceHost
         }
     }
 
-    protected void RegisterStatelessService<TService>(
+    private void RegisterStatelessService<TService>(
         string serviceTypeName,
         Func<StatelessServiceContext, TService> ctor) where TService : StatelessService
     {
@@ -250,7 +250,7 @@ public partial class ServiceHost
         return ConfigureServices(builder => builder.AddScoped<TStartup>());
     }
 
-    protected void Start()
+    private void Start()
     {
         foreach (Func<Task> svc in _serviceCallbacks)
         {

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/ServiceHost.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/ServiceHost.cs
@@ -64,7 +64,7 @@ public partial class ServiceHost
 
     private readonly List<Func<Task>> _serviceCallbacks = new List<Func<Task>>();
 
-    private ServiceHost()
+    protected ServiceHost()
     {
     }
 
@@ -145,7 +145,7 @@ public partial class ServiceHost
         return this;
     }
 
-    private void ApplyConfigurationToServices(IServiceCollection services)
+    protected void ApplyConfigurationToServices(IServiceCollection services)
     {
         foreach (Action<IServiceCollection> act in _configureServicesActions)
         {
@@ -153,7 +153,7 @@ public partial class ServiceHost
         }
     }
 
-    private void RegisterStatelessService<TService>(
+    protected void RegisterStatelessService<TService>(
         string serviceTypeName,
         Func<StatelessServiceContext, TService> ctor) where TService : StatelessService
     {
@@ -244,7 +244,7 @@ public partial class ServiceHost
         return ConfigureServices(builder => builder.AddScoped<TActor>());
     }
 
-    public ServiceHost RegisterStatelessWebService<TStartup>(string serviceTypeName, Action<IWebHostBuilder> configureWebHost = null) where TStartup : class
+    public virtual ServiceHost RegisterStatelessWebService<TStartup>(string serviceTypeName, Action<IWebHostBuilder> configureWebHost = null) where TStartup : class
     {
         RegisterStatelessService(
             serviceTypeName,

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/ServiceHost.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/ServiceHost.cs
@@ -74,10 +74,10 @@ public partial class ServiceHost
     public static void Run(Action<ServiceHost> configure)
     {
         var host = new ServiceHost();
-        host.Start(configure);
+        host.InternalRun(configure);
     }
 
-    protected void Start(Action<ServiceHost> configure)
+    protected void InternalRun(Action<ServiceHost> configure)
     {
         // Because of this issue, the activity tracking causes
         // arbitrarily HttpClient calls to crash, so disable it until

--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/ServiceHost.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/ServiceHost.cs
@@ -73,6 +73,12 @@ public partial class ServiceHost
     /// </summary>
     public static void Run(Action<ServiceHost> configure)
     {
+        var host = new ServiceHost();
+        host.Start(configure);
+    }
+
+    protected void Start(Action<ServiceHost> configure)
+    {
         // Because of this issue, the activity tracking causes
         // arbitrarily HttpClient calls to crash, so disable it until
         // it is fixed
@@ -84,7 +90,7 @@ public partial class ServiceHost
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
             ServicePointManager.CheckCertificateRevocationList = true;
             JsonConvert.DefaultSettings =
-                () => new JsonSerializerSettings {TypeNameHandling = TypeNameHandling.None};
+                () => new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.None };
             var loggingServices = new ServiceCollection();
             ConfigureLoggingServices(loggingServices);
             using var loggingServiceProvider = loggingServices.BuildServiceProvider();
@@ -102,9 +108,8 @@ public partial class ServiceHost
                     "Microsoft-AspNetCore-Server-Kestrel",
                     // dotnet sources
                     "System.Data.DataCommonEventSource");
-                var host = new ServiceHost();
-                configure(host);
-                host.Start();
+                configure(this);
+                Start();
                 packageActivationContext.ReportDeployedServicePackageHealth(
                     new HealthInformation("ServiceHost", "ServiceHost.Run", HealthState.Ok));
                 Thread.Sleep(Timeout.Infinite);
@@ -128,7 +133,7 @@ public partial class ServiceHost
                 {
                     Description = $"Unhandled Exception: {ex}"
                 },
-                new HealthReportSendOptions {Immediate = true});
+                new HealthReportSendOptions { Immediate = true });
             Thread.Sleep(5000);
             Environment.Exit(-1);
         }


### PR DESCRIPTION
https://github.com/dotnet/arcade-services/issues/2783
This change is needed to be able to open up a second http port in Maestro. It allows us to override the needed classes