### PR TITLE
Add ServiceInstanceListener name

### DIFF
--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/DelegatedStatelessWebService.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/DelegatedStatelessWebService.cs
@@ -65,7 +65,7 @@ public class DelegatedStatelessWebService<TStartup> : StatelessService where TSt
                                 .UseUrls(url)
                                 .Build();
                         });
-                });
+                }, name: endpointName);
 
     protected override IEnumerable<ServiceInstanceListener> CreateServiceInstanceListeners() => new[]
     {


### PR DESCRIPTION
The staging Maestro is not working after adding a second ServiceInstanceListener because both are being assigned the [default name](https://learn.microsoft.com/en-us/dotnet/api/microsoft.servicefabric.services.communication.runtime.serviceinstancelistener.-ctor?f1url=https%3A%2F%2Fmsdn.microsoft.com%2Fquery%2Fdev15.query%3FappId%3DDev15IDEF1%26l%3DEN-US%26k%3Dk(Microsoft.ServiceFabric.Services.Communication.Runtime.ServiceInstanceListener.%2523ctor)%3Bk(SolutionItemsProject)%3Bk(TargetFrameworkMoniker-.NETFramework%2CVersion%3Dv4.5.2)%3Bk(DevLang-csharp)%26rd%3Dtrue&view=azure-dotnet). This PR fixes that