### PR TITLE
bump Azure.Identity to 1.10.2

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,7 +12,7 @@
          newer copy of this package loaded. When updating one, be aware of the other to prevent runtime issues
          See: https://github.com/dotnet/arcade/blob/main/eng/Versions.props -->
     <PackageVersion Include="Azure.Data.AppConfiguration" Version="1.0.0" />
-    <PackageVersion Include="Azure.Identity" Version="1.10.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.10.2" />
     <PackageVersion Include="Azure.Security.KeyVault.Secrets" Version="4.4.0" />
     <PackageVersion Include="Azure.Storage.Blobs" Version="12.13.1" />
     <PackageVersion Include="Castle.Core" Version="4.3.0" />


### PR DESCRIPTION
Resolves internal [CG alert](https://dev.azure.com/dnceng/internal/_componentGovernance/dotnet-dnceng-shared/alert/8729354?typeId=15101106&pipelinesTrackingFilter=0) 