### PR TITLE
Put CommandLineLib authentication behind an interface

### DIFF
--- a/src/Microsoft.DncEng.CommandLineLib/Authentication/ITokenCredentialProvider.cs
+++ b/src/Microsoft.DncEng.CommandLineLib/Authentication/ITokenCredentialProvider.cs
@@ -1,0 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Threading.Tasks;
+using Azure.Core;
+
+namespace Microsoft.DncEng.CommandLineLib.Authentication;
+
+public interface ITokenCredentialProvider
+{
+    public Task<TokenCredential> GetCredentialAsync();
+}

--- a/src/Microsoft.DncEng.CommandLineLib/Authentication/TokenCredentialProvider.cs
+++ b/src/Microsoft.DncEng.CommandLineLib/Authentication/TokenCredentialProvider.cs
@@ -9,7 +9,7 @@ using Microsoft.DncEng.Configuration.Extensions;
 
 namespace Microsoft.DncEng.CommandLineLib.Authentication;
 
-public class TokenCredentialProvider
+public class TokenCredentialProvider : ITokenCredentialProvider
 {
     private readonly IConsole _console;
     private readonly InteractiveTokenCredentialProvider _interactiveTokenCredentialProvider;

--- a/src/Microsoft.DncEng.CommandLineLib/DependencyInjectedConsoleApp.cs
+++ b/src/Microsoft.DncEng.CommandLineLib/DependencyInjectedConsoleApp.cs
@@ -44,7 +44,7 @@ public abstract class DependencyInjectedConsoleApp
         services.TryAddSingleton<IConsole, DefaultConsole>();
         services.TryAddSingleton<ISystemClock, SystemClock>();
         services.TryAddSingleton<InteractiveTokenCredentialProvider>();
-        services.TryAddSingleton<TokenCredentialProvider>();
+        services.TryAddSingleton<ITokenCredentialProvider, TokenCredentialProvider>();
         services.AddLogging(ConfigureLogging);
 
         services.TryAddSingleton<ITelemetryInitializer>(provider => provider.GetRequiredService<InteractiveTokenCredentialProvider>());


### PR DESCRIPTION
Put CommandLineLib authentication behind an interface so it may be overridden by consumers.