### PR TITLE
Substitute AcquireTokenWithDeviceCode for AcquireTokenInteractive

### DIFF
--- a/src/Microsoft.DncEng.Configuration.Extensions/LocalDevTokenCredential.cs
+++ b/src/Microsoft.DncEng.Configuration.Extensions/LocalDevTokenCredential.cs
@@ -1,6 +1,3 @@
-// Licensed to the .NET Foundation under one or more agreements.
-// The .NET Foundation licenses this file to you under the MIT license.
-
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -136,7 +133,7 @@ public class LocalDevTokenCredential : TokenCredential
             _account = (await _app.GetAccountsAsync()).FirstOrDefault();
             if (_account == null || uiRequired)
             {
-                var deviceCodeResult = await _app.AcquireTokenWithDeviceCode(requestContext.Scopes, DeviceCodeResultCallback)
+                var deviceCodeResult = await _app.AcquireTokenInteractive(requestContext.Scopes)
                     .ExecuteAsync(cancellationToken);
                 _account = deviceCodeResult.Account;
                 return new AccessToken(deviceCodeResult.AccessToken, deviceCodeResult.ExpiresOn);

--- a/src/Microsoft.DncEng.Configuration.Extensions/LocalDevTokenCredential.cs
+++ b/src/Microsoft.DncEng.Configuration.Extensions/LocalDevTokenCredential.cs
@@ -134,10 +134,10 @@ public class LocalDevTokenCredential : TokenCredential
             _account = (await _app.GetAccountsAsync()).FirstOrDefault();
             if (_account == null || uiRequired)
             {
-                var deviceCodeResult = await _app.AcquireTokenInteractive(requestContext.Scopes)
+                var interactiveToken = await _app.AcquireTokenInteractive(requestContext.Scopes)
                     .ExecuteAsync(cancellationToken);
-                _account = deviceCodeResult.Account;
-                return new AccessToken(deviceCodeResult.AccessToken, deviceCodeResult.ExpiresOn);
+                _account = interactiveToken.Account;
+                return new AccessToken(interactiveToken.AccessToken, interactiveToken.ExpiresOn);
             }
         }
             
@@ -147,23 +147,6 @@ public class LocalDevTokenCredential : TokenCredential
         // When that happens the function will either return the access token from AcquireTokenSilentAsync,
         // or will hit the `uiRequired` branch and call AcquireTokenWithDeviceCode and return
         return await GetTokenAsync(requestContext, cancellationToken);
-    }
-
-    [MethodImpl(MethodImplOptions.NoOptimization)]
-    private static Task DeviceCodeResultCallback(DeviceCodeResult arg)
-    {
-        if (!IsBoostrapping)
-        {
-            throw new InvalidOperationException("Authentication is required, please re-run bootstrap.");
-        }
-        var userCode = arg.UserCode;
-        var verificationUrl = arg.VerificationUrl;
-
-        Console.WriteLine($"To sign in, use a web browser to open the page {verificationUrl} and enter the code {userCode} to authenticate.");
-        Console.WriteLine("Press any key when finished...");
-        Console.ReadKey(true);
-
-        return Task.CompletedTask;
     }
 
     public override AccessToken GetToken(TokenRequestContext requestContext, CancellationToken cancellationToken)

--- a/src/Microsoft.DncEng.Configuration.Extensions/LocalDevTokenCredential.cs
+++ b/src/Microsoft.DncEng.Configuration.Extensions/LocalDevTokenCredential.cs
@@ -1,11 +1,12 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Security.AccessControl;
 using System.Security.Cryptography;
-using System.Security.Principal;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Core;


### PR DESCRIPTION
AcquireTokenWithDeviceCode  is no longer supported for us, I tried to get the token on corpnet and vpn and is not working, changing this to AcquireTokenInteractive, which I already validated and worked as expected 