### PR TITLE
Fix token cache issues during configuration bootstrap

### DIFF
--- a/src/Microsoft.DncEng.Configuration.Extensions/LocalDevTokenCredential.cs
+++ b/src/Microsoft.DncEng.Configuration.Extensions/LocalDevTokenCredential.cs
@@ -125,6 +125,11 @@ public class LocalDevTokenCredential : TokenCredential
                 // will be handled lower
                 uiRequired = true;
             }
+            catch (MsalClientException e) when (e.ErrorCode == "multiple_matching_tokens_detected")
+            {
+                // will be handled lower
+                uiRequired = true;
+            }
         }
 
         // we give the lock a total wait time of 1 hour because the breakpoint to do device code authentication is inside the lock


### PR DESCRIPTION
I was getting this: 

> Unhandled exception. MSAL.NetCore.4.56.0.0.MsalClientException:
        ErrorCode: multiple_matching_tokens_detected
Microsoft.Identity.Client.MsalClientException: The cache contains multiple tokens satisfying the requirements. Try to clear token cache.
   at Microsoft.Identity.Client.Internal.Requests.Silent.SilentRequest.ExecuteAsync(CancellationToken cancellationToken)
   at Microsoft.Identity.Client.Internal.Requests.RequestBase.RunAsync(CancellationToken cancellationToken)
   at Microsoft.Identity.Client.ApiConfig.Executors.ClientApplicationBaseExecutor.ExecuteAsync(AcquireTokenCommonParameters commonParameters, AcquireTokenSilentParameters silentParameters, CancellationToken cancellationToken)
   at Microsoft.DncEng.Configuration.Extensions.LocalDevTokenCredential.GetTokenAsync(TokenRequestContext requestContext, CancellationToken cancellationToken)
   at Microsoft.DncEng.Configuration.Extensions.LocalDevTokenCredential.<>c__DisplayClass21_0.<<GetToken>b__0>d.MoveNext()
--- End of stack trace from previous location ---
   at Microsoft.DncEng.Configuration.Bootstrap.Program.Main(String[] args) in /_/src/Microsoft.DncEng.Configuration.Bootstrap/Program.cs:line 0