### PR TITLE
Reuse Kusto clients

### DIFF
--- a/src/Microsoft.DotNet.Kusto/KustoClientProvider.cs
+++ b/src/Microsoft.DotNet.Kusto/KustoClientProvider.cs
@@ -62,7 +62,7 @@ public sealed class KustoClientProvider : IKustoClientProvider, IDisposable
 
     public async Task<IDataReader> ExecuteKustoQueryAsync(KustoQuery query)
     {
-        using var client = GetProvider();
+        var client = GetProvider();
 
         if (string.IsNullOrEmpty(DatabaseName))
         {
@@ -94,7 +94,7 @@ public sealed class KustoClientProvider : IKustoClientProvider, IDisposable
     /// <returns></returns>
     public async IAsyncEnumerable<object[]> ExecuteStreamableKustoQuery(KustoQuery query)
     {
-        using var client = GetProvider();
+        var client = GetProvider();
 
         if (string.IsNullOrEmpty(DatabaseName))
         {


### PR DESCRIPTION
In my previous PR (https://github.com/dotnet/dnceng-shared/pull/67) I introduced a bug, where we dispose of a Kusto client after it's use. When we try to do it again, it's not set to null, so we don't create a new one, but it's disposed of and that makes it fail. According to the [docs](https://learn.microsoft.com/en-us/azure/data-explorer/kusto/api/netfx/kusto-data-best-practices#:~:text=Data%20library.-,Use%20a%20single%20client%20instance,client%20instance%20rather%20than%20creating%20a%20new%20one%20for%20each%20request.,-Specify%20the%20database) we should reuse it.