### PR TITLE
Allow multiple auth flows

### DIFF
--- a/src/Microsoft.DotNet.Web.Authentication/AccessToken/PersonalAccessTokenAuthenticationHandler.cs
+++ b/src/Microsoft.DotNet.Web.Authentication/AccessToken/PersonalAccessTokenAuthenticationHandler.cs
@@ -144,7 +144,7 @@ public class PersonalAccessTokenAuthenticationHandler<TUser> :
 
             if (user == null)
             {
-                return AuthenticateResult.Fail("Invalid Token");
+                return AuthenticateResult.NoResult();
             }
 
             ClaimsPrincipal principal = await SignInManager.CreateUserPrincipalAsync(user);
@@ -164,9 +164,9 @@ public class PersonalAccessTokenAuthenticationHandler<TUser> :
             return AuthenticateResult.Success(
                 new AuthenticationTicket(context.Principal, context.Properties, Scheme.Name));
         }
-        catch (Exception ex)
+        catch (Exception)
         {
-            return AuthenticateResult.Fail(ex);
+            return AuthenticateResult.NoResult();
         }
     }
 

--- a/src/Microsoft.DotNet.Web.Authentication/AccessToken/PersonalAccessTokenAuthenticationOptions.cs
+++ b/src/Microsoft.DotNet.Web.Authentication/AccessToken/PersonalAccessTokenAuthenticationOptions.cs
@@ -7,13 +7,15 @@ namespace Microsoft.DotNet.Web.Authentication.AccessToken;
 
 public class PersonalAccessTokenAuthenticationOptions<TUser> : AuthenticationSchemeOptions
 {
+    public const int DefaultPasswordSize = 16;
+
     public new PersonalAccessTokenEvents<TUser> Events
     {
         get => (PersonalAccessTokenEvents<TUser>) base.Events;
         set => base.Events = value;
     }
 
-    public int PasswordSize { get; set; } = 16;
+    public int PasswordSize { get; set; } = DefaultPasswordSize;
 
     public string TokenName { get; set; } = "Bearer";
 }


### PR DESCRIPTION
These are small things I found when trying to figure out how to support both entra-based and current auth models.
We must not fail the authentication, just not validate it so that the other flow can do that. That's why we replace `Fail()` with `NoResult()`.
If neither auth flow returns a result, the auth won't happen.

https://dev.azure.com/dnceng/internal/_workitems/edit/6107