### PR TITLE
Adopt latest Octokit

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -62,7 +62,7 @@
     <PackageVersion Include="Newtonsoft.Json.Bson" Version="1.0.2" />
     <PackageVersion Include="NUnit" Version="3.13.3" />
     <PackageVersion Include="NUnit3TestAdapter" Version="3.16.1" />
-    <PackageVersion Include="Octokit" Version="10.0.0" />
+    <PackageVersion Include="Octokit" Version="13.0.1" />
     <PackageVersion Include="Quartz" Version="3.6.2" />
     <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="5.2.1" />
     <PackageVersion Include="Swashbuckle.AspNetCore.Newtonsoft" Version="5.2.1" />


### PR DESCRIPTION
Part of [dotnet/dnceng#3249](https://github.com/dotnet/dnceng/issues/3249)

Adopt latest Octokit, because Integers can get Long.