### PR TITLE
Allow customizing open Kestrel endpoints

### DIFF
--- a/src/Microsoft.DotNet.ServiceFabric.ServiceHost/ServiceHostWebSite.cs
+++ b/src/Microsoft.DotNet.ServiceFabric.ServiceHost/ServiceHostWebSite.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.ServiceFabric.ServiceHost;
 
 public class ServiceHostWebSiteOptions
 {
-    public IReadOnlyCollection<string> Urls { get; set; } = ["http://localhost:8080/"];
+    public IReadOnlyCollection<string> Urls { get; set; } = new[] { "http://localhost:8080/" };
 
     public bool CaptureStartupErrors { get; set; } = true;
 }


### PR DESCRIPTION
Needed to turn on HTTPS locally for Maestro