### PR TITLE
Add keyed DI registration test

### DIFF
--- a/test/Microsoft.DotNet.Internal.DependencyInjection.Testing.Tests/DependencyInjectionTestValidation.cs
+++ b/test/Microsoft.DotNet.Internal.DependencyInjection.Testing.Tests/DependencyInjectionTestValidation.cs
@@ -143,7 +143,7 @@ public class DependencyInjectionTestValidation
         message.Should().Contain(nameof(NeedsSimple));
     }
 
-    // Testing the the library actually checks Keyed registrations
+    // Testing that the library actually checks keyed registrations
     [Test]
     public void KeyedMissingSome_Fail()
     {

--- a/test/Microsoft.DotNet.Internal.DependencyInjection.Testing.Tests/DependencyInjectionTestValidation.cs
+++ b/test/Microsoft.DotNet.Internal.DependencyInjection.Testing.Tests/DependencyInjectionTestValidation.cs
@@ -142,4 +142,15 @@ public class DependencyInjectionTestValidation
         isCoherent.Should().BeFalse();
         message.Should().Contain(nameof(NeedsSimple));
     }
+
+    // Testing the the library actually checks Keyed registrations
+    [Test]
+    public void KeyedMissingSome_Fail()
+    {
+        bool isCoherent = DependencyInjectionValidation.IsDependencyResolutionCoherent(
+            s => { s.AddKeyedSingleton<NeedsSome>("test"); },
+            out string message);
+        isCoherent.Should().BeFalse(message);
+        message.Should().Contain(nameof(NeedsSome));
+    }
 }


### PR DESCRIPTION
I was checking if our library supported Keyed registrations, figured I'd just add this test, as it sounds like a good to have