### PR TITLE
enable PoliCheck, BinSkim, CredScan and TSA in dotnet-dnceng-shared-ci pipeline

### DIFF
--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -1,0 +1,10 @@
+{  
+    "instanceUrl": "https://devdiv.visualstudio.com/",
+    "template": "TFSDEVDIV",
+    "projectName": "DEVDIV",
+    "areaPath": "DevDiv\\NET Fundamentals\\Infrastructure\\Arcade\\SDL",
+    "iterationPath": "DevDiv",
+    "notificationAliases": [ "dnceng@microsoft.com" ],
+    "repositoryName":"dotnet-dnceng-shared",
+    "codebaseName": "dotnet-dnceng-shared"
+}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,15 +29,16 @@ extends:
       name: NetCore1ESPool-Internal
       image: 1es-windows-2019
       os: windows
-    tsa:
-      enabled: true
-    policheck:
-      enabled: true
-    binskim:
-      enabled: true
-      scanOutputDirectoryOnly: true
-    credscan:
-      enabled: true 
+    sdl:
+      tsa:
+        enabled: true
+      policheck:
+        enabled: true
+      binskim:
+        enabled: true
+        scanOutputDirectoryOnly: true
+      credscan:
+        enabled: true 
     stages:
     - stage: build
       dependsOn: []

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,6 +29,15 @@ extends:
       name: NetCore1ESPool-Internal
       image: 1es-windows-2019
       os: windows
+    tsa:
+      enabled: true
+    policheck:
+      enabled: true
+    binskim:
+      enabled: true
+      scanOutputDirectoryOnly: true
+    credscan:
+      enabled: true 
     stages:
     - stage: build
       dependsOn: []


### PR DESCRIPTION
## Related Issue
https://github.com/dotnet/dnceng/issues/4132

## Before merging, please ensure:
- [ ] You have updated any documentation affected by your changes
- [ ] Any new functionality has appropriate unit and/or scenario testing and all tests pass

enable PoliCheck, BinSkim, CredScan and TSA in dotnet-dnceng-shared-ci pipeline

----
#### PR Classification
New feature

#### PR Summary
This pull request enables TSA Upload, PoliCheck, CredScan and BinSkim in the `dotnet-dnceng-shared-ci` pipeline to comply with "The Great Audit" requirements.
- `azure-pipelines.yml`: Enabled TSA, CredScan, PoliCheck, and BinSkim.
- Added `.config/tsaoptions.json` to configure TSA options.
