### PR TITLE
Use `UtcNow` during GH token invalidation

### DIFF
--- a/src/Microsoft.DotNet.GitHub.Authentication/GitHubTokenProvider.cs
+++ b/src/Microsoft.DotNet.GitHub.Authentication/GitHubTokenProvider.cs
@@ -86,7 +86,7 @@ public class GitHubTokenProvider : IGitHubTokenProvider
 
         // If the cached token will expire in less than 50 minutes we won't use it and let GetTokenForInstallationAsync generate a new one
         // and update the cache
-        if (token.ExpiresAt.Subtract(DateTimeOffset.Now).TotalMinutes < 50)
+        if (token.ExpiresAt.Subtract(DateTimeOffset.UtcNow).TotalMinutes < 15)
         {
             return false;
         }

--- a/src/Microsoft.DotNet.GitHub.Authentication/GitHubTokenProvider.cs
+++ b/src/Microsoft.DotNet.GitHub.Authentication/GitHubTokenProvider.cs
@@ -84,7 +84,6 @@ public class GitHubTokenProvider : IGitHubTokenProvider
 
         AccessToken token = _tokenCache[installationId];
 
-        // If the cached token will expire in less than 50 minutes we won't use it and let GetTokenForInstallationAsync generate a new one
         // and update the cache
         if (token.ExpiresAt.Subtract(DateTimeOffset.UtcNow).TotalMinutes < 15)
         {

--- a/src/Microsoft.DotNet.GitHub.Authentication/GitHubTokenProvider.cs
+++ b/src/Microsoft.DotNet.GitHub.Authentication/GitHubTokenProvider.cs
@@ -84,9 +84,9 @@ public class GitHubTokenProvider : IGitHubTokenProvider
 
         AccessToken token = _tokenCache[installationId];
 
-        // If the cached token will expire in less than 12 minutes we won't use it and let GetTokenForInstallationAsync generate a new one
+        // If the cached token will expire in less than 50 minutes we won't use it and let GetTokenForInstallationAsync generate a new one
         // and update the cache
-        if (token.ExpiresAt.Subtract(DateTimeOffset.Now).TotalMinutes < 12)
+        if (token.ExpiresAt.Subtract(DateTimeOffset.Now).TotalMinutes < 50)
         {
             return false;
         }

--- a/src/Microsoft.DotNet.GitHub.Authentication/GitHubTokenProvider.cs
+++ b/src/Microsoft.DotNet.GitHub.Authentication/GitHubTokenProvider.cs
@@ -84,9 +84,9 @@ public class GitHubTokenProvider : IGitHubTokenProvider
 
         AccessToken token = _tokenCache[installationId];
 
-        // If the cached token will expire in less than 30 minutes we won't use it and let GetTokenForInstallationAsync generate a new one
+        // If the cached token will expire in less than 12 minutes we won't use it and let GetTokenForInstallationAsync generate a new one
         // and update the cache
-        if (token.ExpiresAt.Subtract(DateTimeOffset.Now).TotalMinutes < 30)
+        if (token.ExpiresAt.Subtract(DateTimeOffset.Now).TotalMinutes < 12)
         {
             return false;
         }


### PR DESCRIPTION
https://github.com/dotnet/arcade-services/issues/4280