### PR TITLE
Make GitHub token refresh thread safe, fix UTC date comparison

### DIFF
--- a/src/Microsoft.DotNet.GitHub.Authentication/GitHubTokenProvider.cs
+++ b/src/Microsoft.DotNet.GitHub.Authentication/GitHubTokenProvider.cs
@@ -110,7 +110,7 @@ public class GitHubTokenProvider : IGitHubTokenProvider
             return false;
         }
 
-        // If the cached token will expire in less than 30 minutes we won't use it,
+        // If the cached token will expire in less than 15 minutes we won't use it,
         // Instead GetTokenForInstallationAsync will generate a new one and update the cache
         if (cachedToken.ExpiresAt.UtcDateTime.Subtract(DateTime.UtcNow).TotalMinutes < 15)
         {

--- a/src/Microsoft.DotNet.GitHub.Authentication/GitHubTokenProvider.cs
+++ b/src/Microsoft.DotNet.GitHub.Authentication/GitHubTokenProvider.cs
@@ -42,7 +42,9 @@ public class GitHubTokenProvider : IGitHubTokenProvider
     {
         if (TryGetCachedToken(installationId, out AccessToken cachedToken))
         {
-            _logger.LogInformation("Cached token obtained for GitHub installation {installationId}. Expires at {tokenExpiresAt}.", installationId, cachedToken.ExpiresAt);
+            _logger.LogInformation("Cached token obtained for GitHub installation {installationId}. Expires at {tokenExpiresAt}.",
+                installationId,
+                cachedToken.ExpiresAt);
             return cachedToken.Token;
         }
 
@@ -53,7 +55,9 @@ public class GitHubTokenProvider : IGitHubTokenProvider
             {
                 if (TryGetCachedToken(installationId, out cachedToken))
                 {
-                    _logger.LogInformation("Cached token obtained for GitHub installation {installationId}. Expires at {tokenExpiresAt}.", installationId, cachedToken.ExpiresAt);
+                    _logger.LogInformation("Cached token obtained for GitHub installation {installationId}. Expires at {tokenExpiresAt}.",
+                        installationId,
+                        cachedToken.ExpiresAt);
                     return cachedToken.Token;
                 }
 

--- a/src/Microsoft.DotNet.GitHub.Authentication/IGitHubTokenProvider.cs
+++ b/src/Microsoft.DotNet.GitHub.Authentication/IGitHubTokenProvider.cs
@@ -11,6 +11,7 @@ public interface IGitHubTokenProvider
     Task<string> GetTokenForRepository(string repositoryUrl);
     string GetTokenForApp();
     string GetTokenForApp(string name);
+    void InvalidateTokenCacheAsync(long installationId);
 }
 
 public static class GitHubTokenProviderExtensions


### PR DESCRIPTION
- Make sure we only refresh the token from one thread
- Fix comparing the token and current time by using UTC in both

https://github.com/dotnet/dnceng/issues/4856