### PR TITLE
Fixup non-generic AkaMsManager logger type

### DIFF
--- a/src/Microsoft.DotNet.Internal.AkaMsLinks/AkaMsLinksManager.cs
+++ b/src/Microsoft.DotNet.Internal.AkaMsLinks/AkaMsLinksManager.cs
@@ -70,7 +70,7 @@ public class AkaMsLinksManager: IAkaMsLinksManager
     private IHttpClientFactory _clientFactory;
     private ILogger _log;
 
-    public AkaMsLinksManager(TokenCredential credential, ILogger logger, IHttpClientFactory clientFactory)
+    public AkaMsLinksManager(TokenCredential credential, ILogger<AkaMsLinksManager> logger, IHttpClientFactory clientFactory)
     {
         _retryHandler = ExponentialRetry.Default;
         _credential = credential;

--- a/src/Microsoft.DotNet.Internal.AkaMsLinks/AkaMsLinksManager.cs
+++ b/src/Microsoft.DotNet.Internal.AkaMsLinks/AkaMsLinksManager.cs
@@ -78,6 +78,14 @@ public class AkaMsLinksManager: IAkaMsLinksManager
         _clientFactory = clientFactory;
     }
 
+    internal AkaMsLinksManager(TokenCredential credential, ILogger logger, IHttpClientFactory clientFactory)
+    {
+        _retryHandler = ExponentialRetry.Default;
+        _credential = credential;
+        _log = logger;
+        _clientFactory = clientFactory;
+    }
+
     private async Task<HttpClient> CreateClient()
     {
         var token = await _credential.GetTokenAsync(new TokenRequestContext([$"{Endpoint}/.default"]), default);


### PR DESCRIPTION
Resolves https://github.com/dotnet/release/issues/1079

Fixes non-generic typing for logger that was causing issues when the manager was constructed by DI