### PR TITLE
Downgrade GitHub auth library to `net6.0`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -71,6 +71,7 @@
     <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="5.2.1" />
     <PackageVersion Include="Swashbuckle.AspNetCore.Newtonsoft" Version="5.2.1" />
     <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.2.1" />
+    <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageVersion Include="System.IdentityModel.Tokens.Jwt" Version="6.35.0" />
     <PackageVersion Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
     <PackageVersion Include="System.Linq.Async" Version="6.0.1" />

--- a/src/Microsoft.DotNet.GitHub.Authentication/GitHubAppTokenProvider.cs
+++ b/src/Microsoft.DotNet.GitHub.Authentication/GitHubAppTokenProvider.cs
@@ -3,20 +3,22 @@
 
 using System;
 using System.IdentityModel.Tokens.Jwt;
+using System.IO;
+using System.Linq;
 using System.Security.Cryptography;
-using Microsoft.Extensions.Options;
 using System.Text;
 using Microsoft.Extensions.Internal;
+using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 
 namespace Microsoft.DotNet.GitHub.Authentication;
 
 public class GitHubAppTokenProvider : IGitHubAppTokenProvider
 {
-    private readonly TimeProvider _clock;
+    private readonly ISystemClock _clock;
     private readonly IOptionsMonitor<GitHubTokenProviderOptions> _options;
 
-    public GitHubAppTokenProvider(TimeProvider clock, IOptionsMonitor<GitHubTokenProviderOptions> options = null)
+    public GitHubAppTokenProvider(ISystemClock clock, IOptionsMonitor<GitHubTokenProviderOptions> options = null)
     {
         _clock = clock;
         _options = options;
@@ -43,25 +45,189 @@ public class GitHubAppTokenProvider : IGitHubAppTokenProvider
         {
             SetDefaultTimesOnTokenCreation = false
         };
-        using var rsa = RSA.Create(4096); // lgtm [cs/cryptography/default-rsa-key-construction] False positive. This does not use the default constructor.
-        rsa.ImportFromPem(privateKey);
-        var rsaSecurityKey = new RsaSecurityKey(rsa)
+        
+        // Create a new RSA provider with the parameters from the PEM key
+        using (var rsa = CreateRsaProviderFromPrivateKey(privateKey))
         {
-            CryptoProviderFactory =
+            var rsaSecurityKey = new RsaSecurityKey(rsa)
             {
-                // Since we control the lifetime of the key, they can't cache it, since we are about to dispose it
-                CacheSignatureProviders = false
-            }
-        };
-        var signingCredentials = new SigningCredentials(rsaSecurityKey, SecurityAlgorithms.RsaSha256);
-        var dsc = new SecurityTokenDescriptor
+                CryptoProviderFactory =
+                {
+                    // Since we control the lifetime of the key, they can't cache it, since we are about to dispose it
+                    CacheSignatureProviders = false
+                }
+            };
+            var signingCredentials = new SigningCredentials(rsaSecurityKey, SecurityAlgorithms.RsaSha256);
+            var dsc = new SecurityTokenDescriptor
+            {
+                IssuedAt = _clock.UtcNow.AddMinutes(-1).UtcDateTime,
+                Expires = _clock.UtcNow.AddMinutes(9).UtcDateTime,
+                Issuer = gitHubAppId.ToString(),
+                SigningCredentials = signingCredentials
+            };
+            SecurityToken token = handler.CreateToken(dsc);
+            return handler.WriteToken(token);
+        }
+    }
+
+    /// <summary>
+    /// Creates an RSA provider from PEM-encoded private key string
+    /// </summary>
+    /// <param name="privateKey">PEM-encoded private key</param>
+    /// <returns>RSACryptoServiceProvider with the private key</returns>
+    private static RSA CreateRsaProviderFromPrivateKey(string privateKey)
+    {
+        // Remove header/footer and decode
+        var privateKeyBlob = Convert.FromBase64String(ExportBase64FromPem(privateKey));
+        
+        // Use RSACryptoServiceProvider and manually set parameters
+        using (var memoryStream = new MemoryStream(privateKeyBlob))
         {
-            IssuedAt = _clock.GetUtcNow().AddMinutes(-1).UtcDateTime,
-            Expires = _clock.GetUtcNow().AddMinutes(9).UtcDateTime,
-            Issuer = gitHubAppId.ToString(),
-            SigningCredentials = signingCredentials
-        };
-        SecurityToken token = handler.CreateToken(dsc);
-        return handler.WriteToken(token);
+            using (var binaryReader = new BinaryReader(memoryStream))
+            {
+                byte byteValue;
+                ushort shortValue;
+
+                // Skip PKCS#1 header
+                byteValue = binaryReader.ReadByte();
+                if (byteValue != 0x30)
+                    throw new Exception("PKCS#1 header not found");
+
+                // Skip length
+                shortValue = binaryReader.ReadUInt16();
+                
+                // Skip version
+                byteValue = binaryReader.ReadByte();
+                if (byteValue != 0x02)
+                    throw new Exception("Version number not found");
+                
+                shortValue = binaryReader.ReadByte();
+                binaryReader.ReadBytes(shortValue);
+
+                // Parse RSA parameters
+                RSAParameters rsaParams = new RSAParameters();
+
+                // Read modulus
+                byteValue = binaryReader.ReadByte();
+                if (byteValue != 0x02)
+                    throw new Exception("Modulus not found");
+                
+                // Read length
+                rsaParams.Modulus = GetIntegerParameter(binaryReader);
+
+                // Read public exponent
+                byteValue = binaryReader.ReadByte();
+                if (byteValue != 0x02)
+                    throw new Exception("Public exponent not found");
+                
+                rsaParams.Exponent = GetIntegerParameter(binaryReader);
+
+                // Read private exponent
+                byteValue = binaryReader.ReadByte();
+                if (byteValue != 0x02)
+                    throw new Exception("Private exponent not found");
+                
+                rsaParams.D = GetIntegerParameter(binaryReader);
+
+                // Read prime1
+                byteValue = binaryReader.ReadByte();
+                if (byteValue != 0x02)
+                    throw new Exception("Prime1 not found");
+                
+                rsaParams.P = GetIntegerParameter(binaryReader);
+
+                // Read prime2
+                byteValue = binaryReader.ReadByte();
+                if (byteValue != 0x02)
+                    throw new Exception("Prime2 not found");
+                
+                rsaParams.Q = GetIntegerParameter(binaryReader);
+
+                // Read exponent1
+                byteValue = binaryReader.ReadByte();
+                if (byteValue != 0x02)
+                    throw new Exception("Exponent1 not found");
+                
+                rsaParams.DP = GetIntegerParameter(binaryReader);
+
+                // Read exponent2
+                byteValue = binaryReader.ReadByte();
+                if (byteValue != 0x02)
+                    throw new Exception("Exponent2 not found");
+                
+                rsaParams.DQ = GetIntegerParameter(binaryReader);
+
+                // Read coefficient
+                byteValue = binaryReader.ReadByte();
+                if (byteValue != 0x02)
+                    throw new Exception("Coefficient not found");
+                
+                rsaParams.InverseQ = GetIntegerParameter(binaryReader);
+
+                // Create RSA provider and import parameters
+                var rsa = RSA.Create();
+                rsa.ImportParameters(rsaParams);
+                return rsa;
+            }
+        }
+    }
+
+    private static byte[] GetIntegerParameter(BinaryReader reader)
+    {
+        int length = 0;
+        int byteValue = reader.ReadByte();
+        
+        // Handle multi-byte length
+        if (byteValue == 0x81)
+        {
+            length = reader.ReadByte();
+        }
+        else if (byteValue == 0x82)
+        {
+            byte[] lengthBytes = reader.ReadBytes(2);
+            length = (lengthBytes[0] << 8) | lengthBytes[1];
+        }
+        else
+        {
+            length = byteValue;
+        }
+
+        byte[] value = reader.ReadBytes(length);
+        
+        // If the first byte is 0, it's just padding, so remove it
+        if (value.Length > 0 && value[0] == 0)
+        {
+            return value.Skip(1).ToArray();
+        }
+        
+        return value;
+    }
+
+    private static string ExportBase64FromPem(string pem)
+    {
+        // PEM format starts with -----BEGIN RSA PRIVATE KEY----- and ends with -----END RSA PRIVATE KEY-----
+        const string beginMarker = "-----BEGIN RSA PRIVATE KEY-----";
+        const string endMarker = "-----END RSA PRIVATE KEY-----";
+        
+        int startIndex = pem.IndexOf(beginMarker);
+        if (startIndex < 0)
+        {
+            throw new ArgumentException("Invalid PEM format: missing begin marker", nameof(pem));
+        }
+        
+        int endIndex = pem.IndexOf(endMarker, startIndex + beginMarker.Length);
+        if (endIndex < 0)
+        {
+            throw new ArgumentException("Invalid PEM format: missing end marker", nameof(pem));
+        }
+        
+        // Extract the Base64 encoded part
+        string base64 = pem
+            .Substring(startIndex + beginMarker.Length, endIndex - startIndex - beginMarker.Length)
+            .Replace("\n", "")
+            .Replace("\r", "")
+            .Trim();
+            
+        return base64;
     }
 }

--- a/src/Microsoft.DotNet.GitHub.Authentication/GitHubAppTokenProvider.cs
+++ b/src/Microsoft.DotNet.GitHub.Authentication/GitHubAppTokenProvider.cs
@@ -1,12 +1,8 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System;
 using System.IdentityModel.Tokens.Jwt;
-using System.IO;
-using System.Linq;
 using System.Security.Cryptography;
-using System.Text;
 using Microsoft.Extensions.Internal;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
@@ -45,189 +41,25 @@ public class GitHubAppTokenProvider : IGitHubAppTokenProvider
         {
             SetDefaultTimesOnTokenCreation = false
         };
-        
-        // Create a new RSA provider with the parameters from the PEM key
-        using (var rsa = CreateRsaProviderFromPrivateKey(privateKey))
+        using var rsa = RSA.Create(4096); // lgtm [cs/cryptography/default-rsa-key-construction] False positive. This does not use the default constructor.
+        rsa.ImportFromPem(privateKey);
+        var rsaSecurityKey = new RsaSecurityKey(rsa)
         {
-            var rsaSecurityKey = new RsaSecurityKey(rsa)
+            CryptoProviderFactory =
             {
-                CryptoProviderFactory =
-                {
-                    // Since we control the lifetime of the key, they can't cache it, since we are about to dispose it
-                    CacheSignatureProviders = false
-                }
-            };
-            var signingCredentials = new SigningCredentials(rsaSecurityKey, SecurityAlgorithms.RsaSha256);
-            var dsc = new SecurityTokenDescriptor
-            {
-                IssuedAt = _clock.UtcNow.AddMinutes(-1).UtcDateTime,
-                Expires = _clock.UtcNow.AddMinutes(9).UtcDateTime,
-                Issuer = gitHubAppId.ToString(),
-                SigningCredentials = signingCredentials
-            };
-            SecurityToken token = handler.CreateToken(dsc);
-            return handler.WriteToken(token);
-        }
-    }
-
-    /// <summary>
-    /// Creates an RSA provider from PEM-encoded private key string
-    /// </summary>
-    /// <param name="privateKey">PEM-encoded private key</param>
-    /// <returns>RSACryptoServiceProvider with the private key</returns>
-    private static RSA CreateRsaProviderFromPrivateKey(string privateKey)
-    {
-        // Remove header/footer and decode
-        var privateKeyBlob = Convert.FromBase64String(ExportBase64FromPem(privateKey));
-        
-        // Use RSACryptoServiceProvider and manually set parameters
-        using (var memoryStream = new MemoryStream(privateKeyBlob))
-        {
-            using (var binaryReader = new BinaryReader(memoryStream))
-            {
-                byte byteValue;
-                ushort shortValue;
-
-                // Skip PKCS#1 header
-                byteValue = binaryReader.ReadByte();
-                if (byteValue != 0x30)
-                    throw new Exception("PKCS#1 header not found");
-
-                // Skip length
-                shortValue = binaryReader.ReadUInt16();
-                
-                // Skip version
-                byteValue = binaryReader.ReadByte();
-                if (byteValue != 0x02)
-                    throw new Exception("Version number not found");
-                
-                shortValue = binaryReader.ReadByte();
-                binaryReader.ReadBytes(shortValue);
-
-                // Parse RSA parameters
-                RSAParameters rsaParams = new RSAParameters();
-
-                // Read modulus
-                byteValue = binaryReader.ReadByte();
-                if (byteValue != 0x02)
-                    throw new Exception("Modulus not found");
-                
-                // Read length
-                rsaParams.Modulus = GetIntegerParameter(binaryReader);
-
-                // Read public exponent
-                byteValue = binaryReader.ReadByte();
-                if (byteValue != 0x02)
-                    throw new Exception("Public exponent not found");
-                
-                rsaParams.Exponent = GetIntegerParameter(binaryReader);
-
-                // Read private exponent
-                byteValue = binaryReader.ReadByte();
-                if (byteValue != 0x02)
-                    throw new Exception("Private exponent not found");
-                
-                rsaParams.D = GetIntegerParameter(binaryReader);
-
-                // Read prime1
-                byteValue = binaryReader.ReadByte();
-                if (byteValue != 0x02)
-                    throw new Exception("Prime1 not found");
-                
-                rsaParams.P = GetIntegerParameter(binaryReader);
-
-                // Read prime2
-                byteValue = binaryReader.ReadByte();
-                if (byteValue != 0x02)
-                    throw new Exception("Prime2 not found");
-                
-                rsaParams.Q = GetIntegerParameter(binaryReader);
-
-                // Read exponent1
-                byteValue = binaryReader.ReadByte();
-                if (byteValue != 0x02)
-                    throw new Exception("Exponent1 not found");
-                
-                rsaParams.DP = GetIntegerParameter(binaryReader);
-
-                // Read exponent2
-                byteValue = binaryReader.ReadByte();
-                if (byteValue != 0x02)
-                    throw new Exception("Exponent2 not found");
-                
-                rsaParams.DQ = GetIntegerParameter(binaryReader);
-
-                // Read coefficient
-                byteValue = binaryReader.ReadByte();
-                if (byteValue != 0x02)
-                    throw new Exception("Coefficient not found");
-                
-                rsaParams.InverseQ = GetIntegerParameter(binaryReader);
-
-                // Create RSA provider and import parameters
-                var rsa = RSA.Create();
-                rsa.ImportParameters(rsaParams);
-                return rsa;
+                // Since we control the lifetime of the key, they can't cache it, since we are about to dispose it
+                CacheSignatureProviders = false
             }
-        }
-    }
-
-    private static byte[] GetIntegerParameter(BinaryReader reader)
-    {
-        int length = 0;
-        int byteValue = reader.ReadByte();
-        
-        // Handle multi-byte length
-        if (byteValue == 0x81)
+        };
+        var signingCredentials = new SigningCredentials(rsaSecurityKey, SecurityAlgorithms.RsaSha256);
+        var dsc = new SecurityTokenDescriptor
         {
-            length = reader.ReadByte();
-        }
-        else if (byteValue == 0x82)
-        {
-            byte[] lengthBytes = reader.ReadBytes(2);
-            length = (lengthBytes[0] << 8) | lengthBytes[1];
-        }
-        else
-        {
-            length = byteValue;
-        }
-
-        byte[] value = reader.ReadBytes(length);
-        
-        // If the first byte is 0, it's just padding, so remove it
-        if (value.Length > 0 && value[0] == 0)
-        {
-            return value.Skip(1).ToArray();
-        }
-        
-        return value;
-    }
-
-    private static string ExportBase64FromPem(string pem)
-    {
-        // PEM format starts with -----BEGIN RSA PRIVATE KEY----- and ends with -----END RSA PRIVATE KEY-----
-        const string beginMarker = "-----BEGIN RSA PRIVATE KEY-----";
-        const string endMarker = "-----END RSA PRIVATE KEY-----";
-        
-        int startIndex = pem.IndexOf(beginMarker);
-        if (startIndex < 0)
-        {
-            throw new ArgumentException("Invalid PEM format: missing begin marker", nameof(pem));
-        }
-        
-        int endIndex = pem.IndexOf(endMarker, startIndex + beginMarker.Length);
-        if (endIndex < 0)
-        {
-            throw new ArgumentException("Invalid PEM format: missing end marker", nameof(pem));
-        }
-        
-        // Extract the Base64 encoded part
-        string base64 = pem
-            .Substring(startIndex + beginMarker.Length, endIndex - startIndex - beginMarker.Length)
-            .Replace("\n", "")
-            .Replace("\r", "")
-            .Trim();
-            
-        return base64;
+            IssuedAt = _clock.UtcNow.AddMinutes(-1).UtcDateTime,
+            Expires = _clock.UtcNow.AddMinutes(9).UtcDateTime,
+            Issuer = gitHubAppId.ToString(),
+            SigningCredentials = signingCredentials
+        };
+        SecurityToken token = handler.CreateToken(dsc);
+        return handler.WriteToken(token);
     }
 }

--- a/src/Microsoft.DotNet.GitHub.Authentication/InMemoryCacheInstallationLookup.cs
+++ b/src/Microsoft.DotNet.GitHub.Authentication/InMemoryCacheInstallationLookup.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading;
@@ -41,8 +40,8 @@ public class InMemoryCacheInstallationLookup : IInstallationLookup
     public async Task<long> GetInstallationId(string repositoryUrl)
     {
         string[] segments = new Uri(repositoryUrl, UriKind.Absolute).Segments;
-        string org = segments[^2].TrimEnd('/').ToLowerInvariant();
-            
+        string org = segments[segments.Length - 2].TrimEnd('/').ToLowerInvariant();
+
         return await GetInstallationIdForOrg(org);
     }
 
@@ -85,22 +84,27 @@ public class InMemoryCacheInstallationLookup : IInstallationLookup
             {
                 string installedOrg = i.Account.Login.ToLowerInvariant();
                 _log.LogInformation("Found installation token for {org}, with id {id}", installedOrg, i.Id);
-                newCache.Add(installedOrg, i.Id);
+                if (!newCache.ContainsKey(installedOrg))
+                {
+                    newCache.Add(installedOrg, i.Id);
+                }
             }
 
             foreach (string key in _cache.Keys)
             {
                 // Anything we had before but don't have now has been uninstalled, remove it
-                if (newCache.TryAdd(key, 0))
+                if (!newCache.ContainsKey(key))
                 {
+                    newCache.Add(key, 0);
                     _log.LogInformation("Removed uninstalled org {org}", key);
                 }
             }
 
             // If the current thing wasn't in this list, it's not installed, record that so when they ask again in
             // a few seconds, we don't have to re-query GitHub
-            if (newCache.TryAdd(org, 0))
+            if (!newCache.ContainsKey(org))
             {
+                newCache.Add(org, 0);
                 _log.LogInformation("Removed uninstalled, but requested org {org}", org);
             }
 

--- a/src/Microsoft.DotNet.GitHub.Authentication/Microsoft.DotNet.GitHub.Authentication.csproj
+++ b/src/Microsoft.DotNet.GitHub.Authentication/Microsoft.DotNet.GitHub.Authentication.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <SignAssembly>false</SignAssembly>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
@@ -13,7 +13,6 @@
     <PackageReference Include="Octokit" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
-    <PackageReference Include="System.Collections.Immutable" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.GitHub.Authentication/Microsoft.DotNet.GitHub.Authentication.csproj
+++ b/src/Microsoft.DotNet.GitHub.Authentication/Microsoft.DotNet.GitHub.Authentication.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <SignAssembly>false</SignAssembly>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
@@ -12,6 +13,7 @@
     <PackageReference Include="Octokit" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
+    <PackageReference Include="System.Collections.Immutable" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.DotNet.Internal.Testing.Utility/TestClock.cs
+++ b/src/Microsoft.DotNet.Internal.Testing.Utility/TestClock.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace Microsoft.DotNet.Internal.Testing.Utility;
 
-public class TestClock : TimeProvider, Microsoft.Extensions.Internal.ISystemClock
+public class TestClock : TimeProvider, Extensions.Internal.ISystemClock
 {
     public static readonly DateTime BaseTime = DateTime.Parse("2001-02-03T16:05:06Z");
     public DateTimeOffset UtcNow { get; set; } = BaseTime;

--- a/src/Microsoft.DotNet.Services.Utility/Microsoft.DotNet.Services.Utility.csproj
+++ b/src/Microsoft.DotNet.Services.Utility/Microsoft.DotNet.Services.Utility.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/src/Microsoft.DotNet.Services.Utility/Microsoft.DotNet.Services.Utility.csproj
+++ b/src/Microsoft.DotNet.Services.Utility/Microsoft.DotNet.Services.Utility.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 

--- a/test/Microsoft.DotNet.GitHub.Authentication.Tests/GitHubAppTokenProviderTests.cs
+++ b/test/Microsoft.DotNet.GitHub.Authentication.Tests/GitHubAppTokenProviderTests.cs
@@ -2,10 +2,8 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using System;
-using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
-using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.DotNet.Internal.Testing.DependencyInjection.Abstractions;
 using Microsoft.DotNet.Internal.Testing.Utility;
@@ -26,9 +24,10 @@ public partial class GitHubAppTokenProviderTests
             services.AddOptions();
             services.AddLogging(l => l.AddProvider(new NUnitLogger()));
             services.AddSingleton<TimeProvider, TestClock>();
+            services.AddSingleton<ISystemClock, TestClock>();
         }
 
-        public static Func<IServiceProvider,IGitHubAppTokenProvider> Provider(IServiceCollection service, string keyPem)
+        public static Func<IServiceProvider, IGitHubAppTokenProvider> Provider(IServiceCollection service, string keyPem)
         {
             service.Configure<GitHubTokenProviderOptions>(o =>
             {
@@ -54,10 +53,10 @@ public partial class GitHubAppTokenProviderTests
             .Build();
         IGitHubAppTokenProvider provider = testData.Provider;
         string token = provider.GetAppToken();
-        token.Should().Contain(".", because:"valid JWT are in the format XXX.YYY.ZZZ");
+        token.Should().Contain(".", because: "valid JWT are in the format XXX.YYY.ZZZ");
     }
 
-        
+
     // This, unfortunately, isn't something the framework can do for us, but luckily it's an easy thing to do ourselves
     private static string ExportToPem(RSA key)
     {


### PR DESCRIPTION
This is so that we can keep using it in `dotnet/arcade-services` where some projects keep targeting `net6.0`:
https://github.com/dotnet/arcade-services/pull/4814

https://github.com/dotnet/dnceng/issues/1430