### PR TITLE
Make GitHubTokenProvider DI registration more modular

### DIFF
--- a/src/Microsoft.DotNet.GitHub.Authentication/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.DotNet.GitHub.Authentication/ServiceCollectionExtensions.cs
@@ -3,6 +3,8 @@
 
 using Microsoft.DotNet.GitHub.Authentication;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Internal;
 
 namespace Microsoft.DotNet.GitHub.Authentication;
 
@@ -12,6 +14,8 @@ public static class ServiceCollectionExtensions
     {
         return services
             .AddSingleton<IGitHubAppTokenProvider, GitHubAppTokenProvider>()
-            .AddSingleton<IGitHubTokenProvider, GitHubTokenProvider>();
+            .AddSingleton<IGitHubTokenProvider, GitHubTokenProvider>()
+            .TryAddTransient<ISystemClock, SystemClock>()
+            .TryAddTransient<IInstallationLookup, InMemoryCacheInstallationLookup>();
     }
 }

--- a/src/Microsoft.DotNet.GitHub.Authentication/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.DotNet.GitHub.Authentication/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@
 // The .NET Foundation licenses this file to you under the MIT license.
 
 using Microsoft.DotNet.GitHub.Authentication;
+using Microsoft.DotNet.Services.Utility;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Internal;
@@ -15,6 +16,7 @@ public static class ServiceCollectionExtensions
         return services
             .AddSingleton<IGitHubAppTokenProvider, GitHubAppTokenProvider>()
             .AddSingleton<IGitHubTokenProvider, GitHubTokenProvider>()
+            .TryAddSingleton<ExponentialRetry>()
             .TryAddTransient<ISystemClock, SystemClock>()
             .TryAddTransient<IInstallationLookup, InMemoryCacheInstallationLookup>();
     }

--- a/src/Microsoft.DotNet.GitHub.Authentication/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.DotNet.GitHub.Authentication/ServiceCollectionExtensions.cs
@@ -1,7 +1,6 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using Microsoft.DotNet.GitHub.Authentication;
 using Microsoft.DotNet.Services.Utility;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -13,11 +12,11 @@ public static class ServiceCollectionExtensions
 {
     public static IServiceCollection AddGitHubTokenProvider(this IServiceCollection services)
     {
-        return services
-            .TryAddSingleton<IGitHubAppTokenProvider, GitHubAppTokenProvider>()
-            .TryAddSingleton<IGitHubTokenProvider, GitHubTokenProvider>()
-            .TryAddSingleton<ExponentialRetry>()
-            .TryAddTransient<ISystemClock, SystemClock>()
-            .TryAddTransient<IInstallationLookup, InMemoryCacheInstallationLookup>();
+        services.TryAddSingleton<IGitHubAppTokenProvider, GitHubAppTokenProvider>();
+        services.TryAddSingleton<IGitHubTokenProvider, GitHubTokenProvider>();
+        services.TryAddSingleton<ExponentialRetry>();
+        services.TryAddTransient<ISystemClock, SystemClock>();
+        services.TryAddTransient<IInstallationLookup, InMemoryCacheInstallationLookup>();
+        return services;
     }
 }

--- a/src/Microsoft.DotNet.GitHub.Authentication/ServiceCollectionExtensions.cs
+++ b/src/Microsoft.DotNet.GitHub.Authentication/ServiceCollectionExtensions.cs
@@ -14,8 +14,8 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddGitHubTokenProvider(this IServiceCollection services)
     {
         return services
-            .AddSingleton<IGitHubAppTokenProvider, GitHubAppTokenProvider>()
-            .AddSingleton<IGitHubTokenProvider, GitHubTokenProvider>()
+            .TryAddSingleton<IGitHubAppTokenProvider, GitHubAppTokenProvider>()
+            .TryAddSingleton<IGitHubTokenProvider, GitHubTokenProvider>()
             .TryAddSingleton<ExponentialRetry>()
             .TryAddTransient<ISystemClock, SystemClock>()
             .TryAddTransient<IInstallationLookup, InMemoryCacheInstallationLookup>();


### PR DESCRIPTION
There are some missing dependencies that you need to keep registering yourself.