### PR TITLE
Update .NET SDK to 8.0.421 and remove dead DotNet-Blob-Feed variable group

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,22 +57,14 @@ extends:
           - job: Windows_NT
             timeoutInMinutes: 90
             variables:
-            # DotNet-Blob-Feed provides: dotnetfeed-storage-access-key-1
             # DotNet-Symbol-Server-Pats provides: microsoft-symbol-server-pat, symweb-symbol-server-pat
             # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
-            - group: DotNet-Blob-Feed
             - group: DotNet-Symbol-Server-Pats
             - group: Publish-Build-Assets
-            - _PublishBlobFeedUrl: https://dotnetfeed.blob.core.windows.net/dotnet-core/index.json
             - _BuildConfig: Release
-            - _PublishType: blob
             - _SignType: test
-            - _DotNetPublishToBlobFeed: true
             - _InternalBuildArgs: /p:DotNetSignType=$(_SignType)
                 /p:TeamName=$(_TeamName)
-                /p:DotNetPublishBlobFeedKey=$(dotnetfeed-storage-access-key-1)
-                /p:DotNetPublishBlobFeedUrl=$(_PublishBlobFeedUrl)
-                /p:DotNetPublishToBlobFeed=$(_DotNetPublishToBlobFeed)
                 /p:DotNetPublishUsingPipelines=$(_PublishUsingPipelines)
                 /p:DotNetArtifactsCategory=$(_DotNetArtifactsCategory)
                 /p:DotNetSymbolServerTokenMsdl=$(microsoft-symbol-server-pat)

--- a/global.json
+++ b/global.json
@@ -1,11 +1,11 @@
 {
   "sdk": {
-    "version": "8.0.125",
+    "version": "8.0.421",
     "allowPrerelease": true,
     "rollForward": "minor"
   },
   "tools": {
-    "dotnet": "8.0.125",
+    "dotnet": "8.0.421",
     "runtimes": {
       "dotnet": [
         "3.1.32",


### PR DESCRIPTION
Resolves Component Governance alert DOTNET-Security-8.0 (severity: High) detected in .NET SDK 8.0.416.

**Changes:**
1. **global.json** — Update SDK from 8.0.125 → 8.0.421 (latest patched .NET 8.0 SDK)
2. **azure-pipelines.yml** — Remove \DotNet-Blob-Feed\ variable group (no longer exists in AzDO) and associated blob feed publishing variables. The repo already uses the modern BAR/Maestro publishing path (\enablePublishUsingPipelines: true\), making these dead code.

Related work item: AB#9827