### PR TITLE
Migrate CI pool from Windows 2019 to Windows 2022

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,7 +27,7 @@ extends:
   parameters:
     pool:
       name: NetCore1ESPool-Internal
-      image: 1es-windows-2019
+      image: 1es-windows-2022
       os: windows
     sdl:
       tsa:


### PR DESCRIPTION
Windows Server 2019 images have been deprecated by the 1ES Hosted Pool team, causing the `dnceng-shared-ci` pipeline (definition 1245) to fail with:

> 1ES PT Error: MMS Windows Server 2019 is being deprecated by 1ES Hosted Pool team. Please migrate to Windows 2022 or 2025.

This updates the pool image to `1es-windows-2022`, which is already used by the repo's other templates (post-build, onelocbuild, etc.).

**Failed build:** https://dev.azure.com/dnceng/internal/_build/results?buildId=2984653