### PR TITLE
Remove unused Publish-Build-Assets import

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,8 +57,6 @@ extends:
           - job: Windows_NT
             timeoutInMinutes: 90
             variables:
-            # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
-            - group: Publish-Build-Assets
             - _BuildConfig: Release
             - _SignType: test
             - _InternalBuildArgs: /p:DotNetSignType=$(_SignType)


### PR DESCRIPTION
## Summary
- remove the direct `Publish-Build-Assets` variable-group import from dnceng-shared CI
- remove the obsolete comment describing credentials that the pipeline does not consume

The expanded pipeline contains no references to any variable currently supplied by VG20, so no replacement variable group is required.

Tracking: https://dev.azure.com/dnceng/internal/_workitems/edit/12131